### PR TITLE
Net Button fix

### DIFF
--- a/project/src/scene_play.js
+++ b/project/src/scene_play.js
@@ -6,14 +6,13 @@ Ptero.scene_play = (function() {
 	var isPaused = false;
 	function pause() {
 		isPaused = true;
-		disableControls();
 		Ptero.pause_menu.enable();
 		Ptero.pause_menu.animateIn();
 	}
 	function unpause() {
 		isPaused = false;
-		Ptero.pause_menu.disable();
 		enableControls();
+		Ptero.pause_menu.disable();
 	}
 
 	var KEY_SPACE = 32;
@@ -21,6 +20,7 @@ Ptero.scene_play = (function() {
 	var KEY_CTRL = 17;
 	var KEY_ALT = 18;
 	var KEY_A = 65;
+	var KEY_Z = 90;  
 
 	function enableKeys() {
 		window.addEventListener("keydown", onKeyDown);
@@ -37,7 +37,7 @@ Ptero.scene_play = (function() {
 		else if (e.keyCode == KEY_SHIFT) {
 			Ptero.executive.slowmo();
 		}
-		else if (e.keyCode == KEY_ALT) {
+		else if (e.keyCode == KEY_Z) {
 			if (netBtnEnabled) {
 				Ptero.orb.engageNet(true);
 			}
@@ -49,7 +49,7 @@ Ptero.scene_play = (function() {
 		if (e.keyCode == KEY_SHIFT) {
 			Ptero.executive.regmo();
 		}
-		else if (e.keyCode == KEY_ALT) {
+		else if (e.keyCode == KEY_Z) {
 			Ptero.orb.engageNet(false);
 		}
 	}
@@ -76,13 +76,14 @@ Ptero.scene_play = (function() {
 	function enableControls() {
 		pauseBtn.enable();
 		if (shouldNetBtnVisible) {
+			netBtnEnabled = false;
 			enableNetBtn(true);
 		}
 		if (!Ptero.settings.isTutorialEnabled()) {
 			debugBtn1.enable();
 			debugBtn2.enable();
 		}
-		Ptero.orb.enableTouch();
+		Ptero.orb.init();
 		enableKeys();
 	}
 


### PR DESCRIPTION
Fixed an unexpected error when the player holds the net button and simultaneously presses pause. Net would stay engaged on orb, and net button would no longer accept touches.

Fixed by changing when the net button is enabled and re-initializing orb after pause respectively.

Switched KEY_ALT to KEY_Z to prevent browser behaving unexpectedly in linux.
